### PR TITLE
update links

### DIFF
--- a/markup/components/footer.shtml
+++ b/markup/components/footer.shtml
@@ -15,7 +15,7 @@
             <!--#include virtual="/markup/svg/facebook.shtml" -->
             <!-- End Component -->
           </a>
-          <a class="social-link" href="https://twitter.com/TheMissingMaps" target="_blank">
+          <a class="social-link" href="https://twitter.com/mapswipe" target="_blank">
             <!-- Start Component -->
             <!--#include virtual="/markup/svg/twitter.shtml" -->
             <!-- End Component -->


### PR DESCRIPTION
- switching the twitter link to the MapSwipe twitter
- should we remove the Facebook link (goes to Missing Maps right now)?
- should we remove the Instagram link (goes to Missing Maps right now)?
- should we add a link to the [MapSwipe page on the OSM Wiki](https://wiki.openstreetmap.org/wiki/MapSwipe)?